### PR TITLE
made get_R.numeric return the correct output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,8 @@ Title: Estimation of Transmissibility in the Early Stages of a Disease Outbreak
 Version: 0.0.1
 Authors@R: c(person("Thibaut", "Jombart", email = "thibautjombart@gmail.com", role = c("aut", "cre")),
              person("Anne", "Cori", email = "a.cori@imperial.ac.uk", role = c("aut")),
-	     person("Pierre", "Nouvellet", email = "p.nouvellet@imperial.ac.uk", role = c("aut")))
+	     person("Pierre", "Nouvellet", email = "p.nouvellet@imperial.ac.uk", role = c("aut")),
+             person("Janetta", "Skarp", email = "janetta.skarp13@imperial.ac.uk", role = c("aut")))
 Description: Implements a simple, likelihood-based estimation of the reproduction number (R0) using a branching process with a Poisson likelihood. This model requires knowledge of the serial interval distribution, and dates of symptom onsets. Infectiousness is determined by weighting R0 by the probability mass function of the serial interval on the corresponding day. It is a simplified version of the model introduced by Cori et al. (2013) <doi:10.1093/aje/kwt133>.
 Depends: R (>= 3.3.0)
 License: MIT + file LICENSE

--- a/R/get_R.R
+++ b/R/get_R.R
@@ -209,6 +209,7 @@ get_R.integer <- function(x, disease = NULL, si = NULL,
 get_R.numeric <- function(x, ...) {
     out <- get_R(as.integer(x), ...)
     out$incidence <- x
+    return(out)
 }
 
 


### PR DESCRIPTION
get_R should now also work for numeric vectors.